### PR TITLE
Simplify list and itemmetadata parameters

### DIFF
--- a/src/encrypted_models.rs
+++ b/src/encrypted_models.rs
@@ -131,8 +131,8 @@ impl ItemMetadata {
     ///
     /// # Arguments:
     /// * `type` - the type to be set
-    pub fn set_item_type(&mut self, type_: Option<&str>) -> &mut Self {
-        self.type_ = type_.and_then(|x| Some(x.to_string()));
+    pub fn set_item_type<T: AsRef<str>, I: Into<Option<T>>>(&mut self, type_: I) -> &mut Self {
+        self.type_ = type_.into().map(|s| s.as_ref().to_owned());
         self
     }
 
@@ -147,8 +147,8 @@ impl ItemMetadata {
     ///
     /// # Arguments:
     /// * `name` - the name to be set
-    pub fn set_name(&mut self, name: Option<&str>) -> &mut Self {
-        self.name = name.and_then(|x| Some(x.to_string()));
+    pub fn set_name<T: AsRef<str>, I: Into<Option<T>>>(&mut self, name: I) -> &mut Self {
+        self.name = name.into().map(|s| s.as_ref().to_owned());
         self
     }
 
@@ -161,8 +161,8 @@ impl ItemMetadata {
     ///
     /// # Arguments:
     /// * `mtime` - the modification time in milliseconds since epoch
-    pub fn set_mtime(&mut self, mtime: Option<i64>) -> &mut Self {
-        self.mtime = mtime;
+    pub fn set_mtime<I: Into<Option<i64>>>(&mut self, mtime: I) -> &mut Self {
+        self.mtime = mtime.into();
         self
     }
 
@@ -175,8 +175,8 @@ impl ItemMetadata {
     ///
     /// # Arguments:
     /// * `description` - the description to be set
-    pub fn set_description(&mut self, description: Option<&str>) -> &mut Self {
-        self.description = description.and_then(|x| Some(x.to_string()));
+    pub fn set_description<T: AsRef<str>, I: Into<Option<T>>>(&mut self, description: I) -> &mut Self {
+        self.description = description.into().map(|s| s.as_ref().to_owned());
         self
     }
 
@@ -189,8 +189,8 @@ impl ItemMetadata {
     ///
     /// # Arguments:
     /// * `color` - the color to be set in `#RRGGBB` or `#RRGGBBAA` format
-    pub fn set_color(&mut self, color: Option<&str>) -> &mut Self {
-        self.color = color.and_then(|x| Some(x.to_string()));
+    pub fn set_color<I: Into<Option<T>>, T: AsRef<str>>(&mut self, color: I) -> &mut Self {
+        self.color = color.into().map(|s| s.as_ref().to_owned());
         self
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -569,11 +569,12 @@ impl CollectionManager {
     /// * `collection_type` - array of strings denoting the collection types
     /// * `options` - parameters to tune or optimize the fetch
     pub fn list_multi<'a, I>(&self, collection_types: I, options: Option<&FetchOptions>) -> Result<CollectionListResponse<Collection>>
-        where I: Iterator<Item = &'a str>
+        where I: IntoIterator,
+              I::Item: AsRef<str>,
         {
 
         // FIXME: we can avoid this extra allocation
-        let collection_type_uids: Vec<Vec<u8>> = collection_types.map(|x| self.account_crypto_manager.collection_type_to_uid(x).unwrap()).collect();
+        let collection_type_uids: Vec<Vec<u8>> = collection_types.into_iter().map(|x| self.account_crypto_manager.collection_type_to_uid(x.as_ref()).unwrap()).collect();
         let collection_type_uids = collection_type_uids.iter().map(|x| &x[..]);
         let response = self.collection_manager_online.list_multi(collection_type_uids, options)?;
 

--- a/tests/fs_cache.rs
+++ b/tests/fs_cache.rs
@@ -88,7 +88,7 @@ fn simple_cache_handling() -> Result<()> {
     let client = Client::new(CLIENT_NAME, &test_url())?;
     let etebase = init_test_local(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &meta, content)?;
@@ -126,7 +126,7 @@ fn simple_cache_handling() -> Result<()> {
     fs_cache.collection_set_with_content(&col_mgr, &col)?;
     let item_mgr = col_mgr.item_manager(&col)?;
     let item = {
-        let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+        let meta = ItemMetadata::new().set_name("Item 1").clone();
         let content = b"Content 1";
         item_mgr.create(&meta, content)?
     };
@@ -138,7 +138,7 @@ fn simple_cache_handling() -> Result<()> {
     assert_eq!(item2.content()?, item.content()?);
 
     let item = {
-        let meta = ItemMetadata::new().set_name(Some("Item 2")).clone();
+        let meta = ItemMetadata::new().set_name("Item 2").clone();
         let content = b"Content 2";
         item_mgr.create(&meta, content)?
     };

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -134,7 +134,7 @@ fn get_dashboard_url() -> Result<()> {
 fn loading_cache_without_collection_type() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let meta = ItemMetadata::new().set_item_type(Some("type")).set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let meta = ItemMetadata::new().set_item_type("type").set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let content = b"SomeContent";
 
     let col = col_mgr.cache_load(&etebase::utils::from_base64("kgHcBTvMlMyVzNkgTl9vMjNITDFsVlQ1VG5Dd1QzVkx0VDN5TUtBbDZ0UDYBzMDMlMy2QktLMk50R2NCY1pDRDBTcllKeHBzQczEUzXMyVxJSQptzPDMyMzNPMzhAVbMrsyjzPfMjU0pzODMq2lmzMAUEBLM_My-zOhGMsyREmHM6Mz3zO7MwVF8F2tnzOXM3TnM9MypzOQ9CczHfMzGCywPzOPMlsyTzOE-zIRAKczQJzVxRMz9NMz3MczbzMHM5zY_MDrMwsyRzJLM2StoaDhPTTFiQmR5bWZUTlZlanhwcWtPOExWLUpIUDFsUGRST2lCWXhnaEFnzMUEKMy4KGNOJ8z3zN1pzNFGzNLM_8yiCczpzLIxzJQSzNjM58yACS0sP8yCzKDM-GLM0MyCzJMPL8z-Hsz-QMzRT1BCRcyjWszRzLPMkxjMzFYmzMJ8IE1_zMMnCczyzIlUzIbMhxDM3XHMskHM9x9uaWhDzM3Myk1pzI7M78yWzOMrOFHMw04WzK7M-iXMm3tdzKAazMVpzOXMzczqR38KWMyPGEvMzkoyWmodzOvMwczSzLXMplkGzPIDzKvMxGEfQ8zjMcyIdAB4JczLcczfd8z5Vsz4ccyRdMzXzKU1zKcRzP_MycynzLhQzOUvJ8z3FMyHzOpMzLDMm8y6HAw1zKQgJl8CzNrM6XQFRsySFH7Mrn81zPPM4W0HzIPMh1PMpMyUzPNdzNsSzNE6ZQPM9cyGC04eDw7MrR9CaAnM73ZNzJYWOUzMr8zkzK_MxczAzKDMysz5zOt8LlN9zK3MynNizKDM0czXzNhBzNEdNhU8zNTMzTFIb8zmVszHzIfMiALMlkzM68zbzINAzNbMl8z8zMh_T8zHc8zJci7MtkDMl8ywcWIoe1zMuczCRFbMpcy3zJhvzK5PCz4EzMvMlszcAMyWzKIEAMzozPrMlh4JK8z3zMDM8XHMnWLMiMybAijMzczzzOtVaSPM-GbMvXrMksyyzK8_TQ7M9xzMw1PM-lvM68yrXHXM1y5AC0LM6iROcMzmzPzMlBHMtwrM50bMtlrMzX11zIvM4DM4zNIpDC1TEsybQkcuecynQMzCzK_M0sz-zOvMrhdNzJpuzKbM6j7Mjn7M6MzSYszrMzjM5szszIEJYWtfdVs7JVIvS0AQQcyBennMjMzgY8z6zORezOnM5CAZY8z3WWAKPcykT8yVzJDM4BjMz8zNzONtJglpzKRNQQHMxRPM7MymzPnMpy5RzNNIIsyfzKXM9hvMlUbMuczfzK8xzLTM08zlMcyczLLMlGzMrsyOAz7MvMzZzJjMwMyHHsygJMzczMnM1cybzLDMyszqDXrMmGZ3zJTM4nhqZhRhC8yTzMTMtHjM41UTIxvMtMyFzOZ-zIZyHszlzJM9WszhEUbM9VXMmxoNzKfMzUoKKUg9PjYOFMzgzO8jPQzM02TM8BcXzP7Mz8zUfkTMnVRJzIFCzK1ZH8yyzIrMvcy-zP5PzKJjFMygzKvM415LYszXQB_MnCfMzkJmbl_MnmDM42HM88zezOQibhHMuczczMfM2ixwzMvMpczDYRtWzLLM9cydIkjMrxDMj8yYzKkKzLtRzMM1zPbMyS5JYGnM08ylDmdUzL0ANMzgYSfM4jTMm8zvPE0dzL3Mw8zmzOxyzP3M93PM78z1NnoZVxfM7loNfMzxzPHM4j7MpB4NPD0rIczKzN4zKXnMww3M3czlADnMqczxeszuzMDMx8y_B8zyzPYTEjpZPD3M5cz6OALMxH3MgMznzPIXWkMZRzHMuHXMxMzrHEDM9szLaWYSWx4LdMz0zIjM5szMzN3M9syAzKUmWMzbf08QaEc9bMypzOA5bMzjzMQQzJNtVcyCzKJqNmLM0sy1NDMDRcyxzLrMyAzM8hPMv8y5zKoizOzMwEByGszRzIs4HcztNszTzP7M-syyzL_Ms8zFzK5EOk0mYwBGC8yTzO_MynPMrsyxzNMeHszvzI4uzKZ9FTvMzQM2zO0yzNNkzIrM58zfzP7My3rMnMz0zLt9zMgIW8z3zL0ucMy0zK5OZsypT8zOzJnMmMzgGA_M6xLMn8zXzOZ8UnogzL7MtcygzKfMtszUzLXMjUcwbAUQWyzMv8yfLczGcUrM68zdSFlVzJhFzP_M0m3MohzMsljMz8yQGMz-HnBgzJbM3syUzPo7zM3MjknMriHM7QF7YicvBkltX8zeLMyBG3vMq8zNzPPMzcymzIvM4czmEMzTEcyrzK7MtMzszJXMj8z3W8ywzI_MtjHM68yTzKNBEGjMt8y-dTxcbMzATnjMyMzqXHRHHMznzKrMqMy4zKgozLxZDGlZzN7Ml8yAzP99zMdzDwdYTsy2zKYczMcgzKlmasyQzPlDzLRJzMMVzOvM2k3MswbMpjnM53XM-sykzN8QY2YQzMPMjELMwAHMxEjMo8zfFw7MzQEBbcybzJ7M2czrzMTM9x3Mmsy1zILM42xqzIo-MQ_M5czXzLrMxcyozNhHzNsNzLFHzI1vzL3MoyTM3AlKFxzM0WZ0GjnMs8yXURjMm2xhQ8yONGfM28zVzKPMtMzlzIHM6VjM2BLMwA")?)?;
@@ -148,14 +148,14 @@ fn loading_cache_without_collection_type() -> Result<()> {
 fn simple_collection_handling() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let content = b"SomeContent";
 
     let mut col = col_mgr.create("some.coltype", &meta, content)?;
     assert_eq!(col.collection_type()?, "some.coltype");
     verify_collection(&col, &meta, content)?;
 
-    let meta2 = meta.clone().set_name(Some("Collection meta2")).clone();
+    let meta2 = meta.clone().set_name("Collection meta2").clone();
     col.set_meta(&meta2)?;
     verify_collection(&col, &meta2, content)?;
 
@@ -171,19 +171,19 @@ fn simple_collection_handling() -> Result<()> {
 fn simple_item_handling() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
 
     let it_mgr = col_mgr.item_manager(&col)?;
 
-    let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+    let meta = ItemMetadata::new().set_name("Item 1").clone();
     let content = b"ItemContent";
     let mut item = it_mgr.create(&meta, content)?;
     verify_item(&item, &meta, content)?;
 
-    let meta2 = ItemMetadata::new().set_name(Some("Item 2")).clone();
+    let meta2 = ItemMetadata::new().set_name("Item 2").clone();
     item.set_meta(&meta2)?;
     verify_item(&item, &meta2, content)?;
 
@@ -199,7 +199,7 @@ fn simple_item_handling() -> Result<()> {
 fn simple_collection_sync() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let content = b"SomeContent";
 
     let mut col = col_mgr.create("some.coltype", &meta, content)?;
@@ -221,7 +221,7 @@ fn simple_collection_sync() -> Result<()> {
         assert_eq!(collections.data().len(), 0);
     }
 
-    let meta2 = meta.clone().set_name(Some("Collection meta2")).clone();
+    let meta2 = meta.clone().set_name("Collection meta2").clone();
     col.set_meta(&meta2)?;
 
     col_mgr.upload(&col, None)?;
@@ -259,7 +259,7 @@ fn simple_collection_sync() -> Result<()> {
 fn collection_types() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -294,7 +294,7 @@ fn collection_types() -> Result<()> {
 fn simple_item_sync() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -303,7 +303,7 @@ fn simple_item_sync() -> Result<()> {
 
     let it_mgr = col_mgr.item_manager(&col)?;
 
-    let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+    let meta = ItemMetadata::new().set_name("Item 1").clone();
     let content = b"Content 1";
 
     let mut item = it_mgr.create(&meta, content)?;
@@ -318,7 +318,7 @@ fn simple_item_sync() -> Result<()> {
 
     let mut item_old = it_mgr.fetch(item.uid(), None)?;
 
-    let meta2 = ItemMetadata::new().set_name(Some("Item 2")).clone();
+    let meta2 = ItemMetadata::new().set_name("Item 2").clone();
     item.set_meta(&meta2)?;
 
     let col_old = col_mgr.fetch(col.uid(), None)?;
@@ -361,7 +361,7 @@ fn simple_item_sync() -> Result<()> {
 fn collection_as_item() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let mut col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -439,7 +439,7 @@ fn collection_as_item() -> Result<()> {
 fn collection_and_item_deletion() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let mut col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -448,7 +448,7 @@ fn collection_and_item_deletion() -> Result<()> {
 
     let it_mgr = col_mgr.item_manager(&col)?;
 
-    let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+    let meta = ItemMetadata::new().set_name("Item 1").clone();
     let content = b"Content 1";
 
     let mut item = it_mgr.create(&meta, content)?;
@@ -490,7 +490,7 @@ fn collection_and_item_deletion() -> Result<()> {
 fn empty_content() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -504,7 +504,7 @@ fn empty_content() -> Result<()> {
 
     let it_mgr = col_mgr.item_manager(&col)?;
 
-    let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+    let meta = ItemMetadata::new().set_name("Item 1").clone();
     let content = b"";
 
     let item = it_mgr.create(&meta, content)?;
@@ -524,7 +524,7 @@ fn empty_content() -> Result<()> {
 fn list_response_correctness() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -540,7 +540,7 @@ fn list_response_correctness() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -567,7 +567,7 @@ fn list_response_correctness() -> Result<()> {
 
     // Also check collections
     for i in 0..4 {
-        let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+        let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
         let content = b"";
         let col = col_mgr.create("some.coltype", &meta, content).unwrap();
         col_mgr.upload(&col, None)?;
@@ -598,7 +598,7 @@ fn list_response_correctness() -> Result<()> {
 fn item_transactions() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -606,7 +606,7 @@ fn item_transactions() -> Result<()> {
     col_mgr.upload(&col, None)?;
 
     let it_mgr = col_mgr.item_manager(&col)?;
-    let meta = ItemMetadata::new().set_name(Some("Item 1")).clone();
+    let meta = ItemMetadata::new().set_name("Item 1").clone();
     let content = b"";
     let mut item = it_mgr.create(&meta, content)?;
 
@@ -618,7 +618,7 @@ fn item_transactions() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -631,7 +631,7 @@ fn item_transactions() -> Result<()> {
         assert_eq!(items.data().len(), 6);
     }
 
-    let meta2 = ItemMetadata::new().set_name(Some("some")).clone();
+    let meta2 = ItemMetadata::new().set_name("some").clone();
     item.set_meta(&meta2)?;
     let deps = vec![&item];
 
@@ -643,7 +643,7 @@ fn item_transactions() -> Result<()> {
     }
 
     {
-        let meta3 = ItemMetadata::new().set_name(Some("some2")).clone();
+        let meta3 = ItemMetadata::new().set_name("some2").clone();
         item.set_meta(&meta3)?;
 
         let deps2 = items.iter().chain(iter::once(&item_old));
@@ -659,7 +659,7 @@ fn item_transactions() -> Result<()> {
     }
 
     {
-        let meta3 = ItemMetadata::new().set_name(Some("some3")).clone();
+        let meta3 = ItemMetadata::new().set_name("some3").clone();
         let mut item2 = it_mgr.fetch(items[0].uid(), None)?;
         item2.set_meta(&meta3)?;
 
@@ -675,7 +675,7 @@ fn item_transactions() -> Result<()> {
 
     {
         // Global stoken test
-        let meta3 = ItemMetadata::new().set_name(Some("some4")).clone();
+        let meta3 = ItemMetadata::new().set_name("some4").clone();
         item.set_meta(&meta3)?;
 
         let new_col = col_mgr.fetch(col.uid(), None)?;
@@ -696,7 +696,7 @@ fn item_transactions() -> Result<()> {
 fn item_batch_stoken() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -704,7 +704,7 @@ fn item_batch_stoken() -> Result<()> {
     col_mgr.upload(&col, None)?;
 
     let it_mgr = col_mgr.item_manager(&col)?;
-    let meta = ItemMetadata::new().set_name(Some("Item Orig")).clone();
+    let meta = ItemMetadata::new().set_name("Item Orig").clone();
     let content = b"";
     let mut item = it_mgr.create(&meta, content)?;
 
@@ -714,7 +714,7 @@ fn item_batch_stoken() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -723,11 +723,11 @@ fn item_batch_stoken() -> Result<()> {
     it_mgr.batch(items.iter(), None)?;
 
     {
-        let meta3 = ItemMetadata::new().set_name(Some("some2")).clone();
+        let meta3 = ItemMetadata::new().set_name("some2").clone();
         item2.set_meta(&meta3)?;
         it_mgr.batch(iter::once(&item2), None)?;
 
-        let meta3 = ItemMetadata::new().set_name(Some("some3")).clone();
+        let meta3 = ItemMetadata::new().set_name("some3").clone();
         item.set_meta(&meta3)?;
 
         // Old stoken in the item itself should work for batch and fail for transaction or batch with deps
@@ -739,7 +739,7 @@ fn item_batch_stoken() -> Result<()> {
 
     {
         // Global stoken test
-        let meta3 = ItemMetadata::new().set_name(Some("some4")).clone();
+        let meta3 = ItemMetadata::new().set_name("some4").clone();
         item.set_meta(&meta3)?;
 
         let new_col = col_mgr.fetch(col.uid(), None)?;
@@ -760,7 +760,7 @@ fn item_batch_stoken() -> Result<()> {
 fn item_fetch_updates() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -768,7 +768,7 @@ fn item_fetch_updates() -> Result<()> {
     col_mgr.upload(&col, None)?;
 
     let it_mgr = col_mgr.item_manager(&col)?;
-    let meta = ItemMetadata::new().set_name(Some("Item Orig")).clone();
+    let meta = ItemMetadata::new().set_name("Item Orig").clone();
     let content = b"";
     let item = it_mgr.create(&meta, content)?;
 
@@ -776,7 +776,7 @@ fn item_fetch_updates() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -803,7 +803,7 @@ fn item_fetch_updates() -> Result<()> {
 
     {
         let mut item2 = it_mgr.fetch(items[0].uid(), None)?;
-        let meta3 = ItemMetadata::new().set_name(Some("some2")).clone();
+        let meta3 = ItemMetadata::new().set_name("some2").clone();
         item2.set_meta(&meta3)?;
         it_mgr.batch(iter::once(&item2), None)?;
     }
@@ -843,7 +843,7 @@ fn item_fetch_updates() -> Result<()> {
 fn item_revisions() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -851,18 +851,18 @@ fn item_revisions() -> Result<()> {
     col_mgr.upload(&col, None)?;
 
     let it_mgr = col_mgr.item_manager(&col)?;
-    let meta = ItemMetadata::new().set_name(Some("Item Orig")).clone();
+    let meta = ItemMetadata::new().set_name("Item Orig").clone();
     let content = b"";
     let mut item = it_mgr.create(&meta, content)?;
 
     for i in 0..5 {
-        let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+        let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
         item.set_meta(&meta)?;
         it_mgr.batch(iter::once(&item), None)?;
     }
 
     {
-        let meta = ItemMetadata::new().set_name(Some("Latest")).clone();
+        let meta = ItemMetadata::new().set_name("Latest").clone();
         item.set_meta(&meta)?;
         it_mgr.batch(iter::once(&item), None)?;
     }
@@ -881,7 +881,7 @@ fn item_revisions() -> Result<()> {
         assert!(revisions.done());
 
         for i in 0..5 {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let rev = &revisions.data()[4 - i];
             assert_eq!(&rev.meta()?, &meta);
         }
@@ -905,7 +905,7 @@ fn item_revisions() -> Result<()> {
 fn collection_invitations() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -916,7 +916,7 @@ fn collection_invitations() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -1068,7 +1068,7 @@ fn iterating_invitations() -> Result<()> {
     let user2_profile = invite_mgr.fetch_user_profile(USER2.username)?;
 
     for i in 0..3 {
-        let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+        let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
         let content = b"";
         let col = col_mgr.create("some.coltype", &meta, content).unwrap();
         col_mgr.upload(&col, None)?;
@@ -1111,7 +1111,7 @@ fn iterating_invitations() -> Result<()> {
 fn collection_access_level() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").clone();
     let col_content = b"";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -1121,7 +1121,7 @@ fn collection_access_level() -> Result<()> {
 
     let items: Vec<Item> = (0..5).into_iter()
         .map(|i| {
-            let meta = ItemMetadata::new().set_name(Some(&format!("Item {}", i))).clone();
+            let meta = ItemMetadata::new().set_name(&format!("Item {}", i)).clone();
             let content = b"";
             it_mgr.create(&meta, content).unwrap()
         })
@@ -1157,7 +1157,7 @@ fn collection_access_level() -> Result<()> {
             }
         }
 
-        let meta = ItemMetadata::new().set_name(Some("Some item")).clone();
+        let meta = ItemMetadata::new().set_name("Some item").clone();
         let content = b"";
         let item = it_mgr2.create(&meta, content)?;
         it_mgr2.batch(iter::once(&item), None)?;
@@ -1178,7 +1178,7 @@ fn collection_access_level() -> Result<()> {
             }
         }
 
-        let meta = ItemMetadata::new().set_name(Some("Some item")).clone();
+        let meta = ItemMetadata::new().set_name("Some item").clone();
         let content = b"";
         let item = it_mgr2.create(&meta, content)?;
         assert_err!(it_mgr2.batch(iter::once(&item), None), Error::PermissionDenied(_));
@@ -1196,7 +1196,7 @@ fn collection_access_level() -> Result<()> {
             }
         }
 
-        let meta = ItemMetadata::new().set_name(Some("Some item")).clone();
+        let meta = ItemMetadata::new().set_name("Some item").clone();
         let content = b"";
         let item = it_mgr2.create(&meta, content)?;
         it_mgr2.batch(iter::once(&item), None)?;
@@ -1226,7 +1226,7 @@ fn collection_access_level() -> Result<()> {
 fn chunking_large_data() -> Result<()> {
     let etebase = init_test(&USER)?;
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -1290,7 +1290,7 @@ fn login_and_password_change_with_key() -> Result<()> {
     let etebase = init_test(&USER)?;
 
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col = col_mgr.create("some.coltype", &col_meta, b"")?;
     col_mgr.upload(&col, None)?;
 
@@ -1324,7 +1324,7 @@ fn signup_with_key() -> Result<()> {
     let etebase = Account::signup_key(client, &user, &main_key)?;
 
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col = col_mgr.create("some.coltype", &col_meta, b"")?;
     col_mgr.upload(&col, None)?;
 
@@ -1354,7 +1354,7 @@ fn login_and_password_change() -> Result<()> {
     let mut etebase2 = Account::login(client.clone(), USER2.username, USER2.password)?;
 
     let col_mgr2 = etebase2.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr2.create("some.coltype", &col_meta, col_content)?;
@@ -1394,7 +1394,7 @@ fn session_save_and_restore() -> Result<()> {
     let etebase = init_test(&USER)?;
 
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -1430,7 +1430,7 @@ fn cache_collections_and_items() -> Result<()> {
     let etebase = init_test(&USER)?;
 
     let col_mgr = etebase.collection_manager()?;
-    let col_meta = ItemMetadata::new().set_name(Some("Collection")).set_description(Some("Mine")).set_color(Some("#aabbcc")).clone();
+    let col_meta = ItemMetadata::new().set_name("Collection").set_description("Mine").set_color("#aabbcc").clone();
     let col_content = b"SomeContent";
 
     let col = col_mgr.create("some.coltype", &col_meta, col_content)?;
@@ -1438,7 +1438,7 @@ fn cache_collections_and_items() -> Result<()> {
 
     let it_mgr = col_mgr.item_manager(&col)?;
 
-    let meta = ItemMetadata::new().set_name(Some("Item")).clone();
+    let meta = ItemMetadata::new().set_name("Item").clone();
     let content = b"SomeItemContent";
     let item = it_mgr.create(&meta, content)?;
 


### PR DESCRIPTION
While working on the rust docs I found some functions that are not that ergonomic for the user.
With these changes `list_multi` can be called with slices and vecs and without calling into iter:
```rust
col_mgr.list_multi(&[String::from(""),String::new()], None)?;
col_mgr.list_multi(&["tasks","calendar"], None)?;
col_mgr.list_multi(vec!["tasks","calendar"], None)?;
col_mgr.list_multi(vec!["tasks","calendar"].into_iter(), None)?;
```

The ItemMetadata can now take `str`, `String` or `None`:
```rust
ItemMetadata::new().set_color(String::from("#ccc"));
ItemMetadata::new().set_color("#ccc");
ItemMetadata::new().set_mtime(None);
ItemMetadata::new().set_mtime(0);
```
What I'm not too happy about is that calling the setter with `Some(...)` now requires type annotations:
```rust
ItemMetadata::new().set_color::<Option<_>, String>(Some(String::from("#ccc")));
```
obviously no one would use it like this if it's also possible to call without explicit`Some`, but it's still a breaking change...

I'm happy to split this in to PRs if that's desired

A future improvement to the ItemMetadata setter would be to change their signature to:
```rust
pub fn set_xyz<...>(mut self, description: I) -> Self
```
then we could get rid of the `clone()` calls.