### PR TITLE
Check for exact key length

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -157,12 +157,12 @@ impl Account {
     /// # Arguments:
     /// * `client` - the already setup [Client] object
     /// * `user` - the already setup [User] object
-    /// * `main_key` - the key to signup with
+    /// * `main_key` - the 32-byte key to signup with
     pub fn signup_key(client: Client, user: &User, main_key: &[u8]) -> Result<Self> {
         super::init()?;
 
-        if main_key.len() < SYMMETRIC_KEY_SIZE {
-            return Err(Error::ProgrammingError("Key should be at least 32 bytes long."));
+        if main_key.len() == SYMMETRIC_KEY_SIZE {
+            return Err(Error::ProgrammingError("Key should be exactly 32 bytes long."));
         }
 
         let salt = randombytes(32);


### PR DESCRIPTION
The `try_into!` in `signup_common` is converting to a `&[u8; 32]`, and
fails for anything not 32 bytes long with a not-very-helpful `TryInto
failed`.  This change produces a better error message for that case, and
adjusts the docs.

It would be an API-breaking change to update the type of `main_key` to `&[u8; 32]`, but would surface this error at build time instead of runtime.  I'm not sure whether that's worth it.

(I ran into this while working on #15 and thought I'd fix it)