### PR TITLE
Fix sodiumoxide version to v0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ include = [
 crate-type = ["lib"]
 
 [dependencies]
-sodiumoxide = "^0.2.6"
-libsodium-sys = "^0.2.6"
+sodiumoxide = "=0.2.6"
+libsodium-sys = "=0.2.6"
 url = "^2.1.1"
 serde = { version = "^1.0.105", features = ["derive"] }
 serde_bytes = "^0.11.5"


### PR DESCRIPTION
Hi. Thank you for great library. I've just started trying this, and I'm now enjoying it ;)

## Summary

To prevent errors, I've made a small pull request fixes the version of sodiumoxide (and libsodium-sys) to `v0.2.6` as locked in the current Cargo.lock.

## Backgrounds

When I tried adding etebase-rs into a binary crate, sodiumoxide `v0.2.7` was installed and I faced the following errors:

<details>
  <summary>Instructions</summary>

```bash
# create a binary crate
$ cargo new --bin foo
$ cd foo

# add etebase-rs
$ cat Cargo.toml
...
[dependencies]
etebase = "^0.5.0"

# and compile dependencies
$ cargo check
...
Compiling libsodium-sys v0.2.7
Checking sodiumoxide v0.2.7
...
```
</details>

<details>
  <summary>Errors</summary>

```
error[E0423]: expected function, tuple struct or tuple variant, found struct `sign::Signature`
   --> /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/etebase-0.5.0/src/crypto.rs:193:25
    |
193 |         let signature = sign::Signature(signature_copy);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `sign::Signature { 0: val }`
    | 
   ::: /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/ed25519-1.1.1/src/lib.rs:275:1
    |
275 | pub struct Signature([u8; SIGNATURE_LENGTH]);
    | --------------------------------------------- `sign::Signature` defined here

error[E0308]: mismatched types
  --> /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/etebase-0.5.0/src/crypto.rs:28:59
   |
28 |     let mut state = to_enc_error!(generichash::State::new(32, key), "Failed to init hash")?;
   |                                                           ^^
   |                                                           |
   |                                                           expected enum `std::option::Option`, found integer
   |                                                           help: try using a variant of the expected enum: `online_managers::_::_serde::__private::Some(32)`
   |
   = note: expected enum `std::option::Option<usize>`
              found type `{integer}`

error[E0608]: cannot index into a value of type `Signature`
   --> /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/etebase-0.5.0/src/crypto.rs:187:12
    |
187 |         Ok(ret[..].to_vec())
    |            ^^^^^^^

error[E0308]: mismatched types
   --> /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/etebase-0.5.0/src/crypto.rs:272:59
    |
272 |         let state = to_enc_error!(generichash::State::new(32, key), "Failed to init hash")?;
    |                                                           ^^
    |                                                           |
    |                                                           expected enum `std::option::Option`, found integer
    |                                                           help: try using a variant of the expected enum: `online_managers::_::_serde::__private::Some(32)`
    |
    = note: expected enum `std::option::Option<usize>`
               found type `{integer}`

error: aborting due to 4 previous errors

Some errors have detailed explanations: E0308, E0423, E0608.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `etebase`

To learn more, run the command again with --verbose.
```
</details>

On the other hand, If I clone etebase-rs directly, and try compiling it in the project directory, I don't see any issues like that, since the versions are locked as `v0.2.6` in [Cargo.lock](https://github.com/etesync/etebase-rs/blob/ce2dbb5a48a06e54ade2f733f99a4ac0af729df3/Cargo.lock) file for now:

<details>
  <summary>Instructions</summary>

```bash
$ git clone git@github.com:etesync/etebase-rs.git
$ cd etebase-rs

# this installs v0.2.6 and works
$ cargo check
...
Compiling libsodium-sys v0.2.6
Checking sodiumoxide v0.2.6
```
</details>

<details>
  <summary>Cargo.lock</summary>

```TOML
[[package]]
name = "sodiumoxide"
version = "0.2.6"
...
[[package]]
name = "libsodium-sys"
version = "0.2.6"
...
```
</details>

Apparently, it seems that the errors are related to changes between [v0.2.6 and v0.2.7](https://github.com/sodiumoxide/sodiumoxide/compare/0.2.6...0.2.7) in sodiumoxide side.
https://github.com/sodiumoxide/sodiumoxide/issues/469

And the difference is brought by existence of Cargo.lock file in this repository.

## Supplements

If we add Cargo.lock to a library crate, when we use the crate from a binary crate, somehow the file seems to be not used. So I guess that any library crate may not want to include Cargo.lock file.

I've found also a doc mentions about this.
[Why do binaries have Cargo.lock in version control, but not libraries?](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries)
\# If it's intended for reason. Sorry about that. Please ignore.

And also fixing code on etebase-rs side to meet the changes in sodiumoxide `v0.2.7` is not so complicated (I actually tried it on my local), but it's related to cryptography, so I guess that you may want to check details before updating it. Thus I've fixed only the versions as `v0.2.6` like this at this time.

I hope that this makes sense.

Finally, I've tested this with `path` like so:

<details>
  <summary>Cargo.toml</summary>

```TOML
...
[dependencies]
etebase = { path = "../etebase-rs" }
```
</details>
