### PR TITLE
Update to sodiumoxide 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
+name = "ed25519"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,13 +411,14 @@ checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "libsodium-sys"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -799,6 +809,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,10 +938,11 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "sodiumoxide"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
+ "ed25519",
  "libc",
  "libsodium-sys",
  "serde",
@@ -1068,6 +1094,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.8",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1225,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ include = [
 crate-type = ["lib"]
 
 [dependencies]
-sodiumoxide = "^0.2.6"
-libsodium-sys = "^0.2.6"
+sodiumoxide = "^0.2.7"
+libsodium-sys = "^0.2.7"
 url = "^2.1.1"
 serde = { version = "^1.0.105", features = ["derive"] }
 serde_bytes = "^0.11.5"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -17,7 +17,7 @@ macro_rules! to_enc_error {
 }
 
 fn generichash_quick(msg: &[u8], key: Option<&[u8]>) -> Result<Vec<u8>> {
-    let mut state = to_enc_error!(generichash::State::new(32, key), "Failed to init hash")?;
+    let mut state = to_enc_error!(generichash::State::new(Some(32), key), "Failed to init hash")?;
     to_enc_error!(state.update(msg), "Failed to update hash")?;
     Ok(to_enc_error!(state.finalize(), "Failed to finalize hash")?
         .as_ref()
@@ -248,7 +248,7 @@ impl LoginCryptoManager {
     pub fn sign_detached(&self, msg: &[u8]) -> Result<Vec<u8>> {
         let ret = sign::sign_detached(msg, &self.privkey);
 
-        Ok(ret[..].to_vec())
+        Ok(ret.to_bytes().to_vec())
     }
 
     pub fn verify_detached(
@@ -259,7 +259,7 @@ impl LoginCryptoManager {
     ) -> Result<bool> {
         let mut signature_copy = [0; 64];
         signature_copy[..].copy_from_slice(&signature[..]);
-        let signature = sign::Signature(signature_copy);
+        let signature = sign::Signature::new(signature_copy);
         let pubkey = sign::PublicKey(*pubkey);
         let ret = sign::verify_detached(&signature, msg, &pubkey);
 
@@ -336,7 +336,7 @@ pub struct CryptoMac {
 
 impl CryptoMac {
     pub fn new(key: Option<&[u8]>) -> Result<Self> {
-        let state = to_enc_error!(generichash::State::new(32, key), "Failed to init hash")?;
+        let state = to_enc_error!(generichash::State::new(Some(32), key), "Failed to init hash")?;
 
         Ok(Self { state })
     }


### PR DESCRIPTION
Fix some of the issues presented in issue #22, including the breaking changes between 0.2.6 and 0.2.7, except by upgrading the library instead of locking it into an older version.

Closes #22