### PR TITLE
CI: cleanup, check code formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,50 +7,41 @@ on:
     branches: [ master ]
 
 jobs:
+  clippy:
+    name: Clippy lints
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-go@v2.1.3
-      - uses: actions/checkout@v2
-
-      - uses: actions/checkout@v1
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
 
       - name: Run local test Server
         run: |
           docker run -d -p 3735:3735 etesync/test-server:latest
           ./scripts/wait-for-it.sh localhost:3735
 
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1.0.1
-        with:
-          command: check
-
-      - name: test
+      - name: Run tests
         env:
           ETEBASE_TEST_HOST: localhost:3735
         run: cargo test -- --test-threads=1
-
-      - run: rustup component add clippy
-
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   formatting:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features -- -D warnings
 
   test:
     name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
+  formatting:
+    name: Code formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
   clippy:
     name: Clippy lints
     runs-on: ubuntu-latest

--- a/examples/etebase_test.rs
+++ b/examples/etebase_test.rs
@@ -42,12 +42,12 @@ fn main() -> Result<()> {
 
         print_collection(&col);
         for item in items.data() {
-            print_item(&item);
+            print_item(item);
         }
     } else {
         let collections = col_mgr.list("some.coltype", None)?;
         for col in collections.data() {
-            print_collection(&col);
+            print_collection(col);
         }
     }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -17,7 +17,10 @@ macro_rules! to_enc_error {
 }
 
 fn generichash_quick(msg: &[u8], key: Option<&[u8]>) -> Result<Vec<u8>> {
-    let mut state = to_enc_error!(generichash::State::new(Some(32), key), "Failed to init hash")?;
+    let mut state = to_enc_error!(
+        generichash::State::new(Some(32), key),
+        "Failed to init hash"
+    )?;
     to_enc_error!(state.update(msg), "Failed to update hash")?;
     Ok(to_enc_error!(state.finalize(), "Failed to finalize hash")?
         .as_ref()
@@ -259,7 +262,10 @@ impl LoginCryptoManager {
     ) -> Result<bool> {
         let mut signature_copy = [0; 64];
         signature_copy[..].copy_from_slice(&signature[..]);
-        let signature = to_enc_error!(sign::Signature::from_bytes(&signature_copy), "siganture copy failed")?;
+        let signature = to_enc_error!(
+            sign::Signature::from_bytes(&signature_copy),
+            "siganture copy failed"
+        )?;
         let pubkey = sign::PublicKey(*pubkey);
         let ret = sign::verify_detached(&signature, msg, &pubkey);
 
@@ -336,7 +342,10 @@ pub struct CryptoMac {
 
 impl CryptoMac {
     pub fn new(key: Option<&[u8]>) -> Result<Self> {
-        let state = to_enc_error!(generichash::State::new(Some(32), key), "Failed to init hash")?;
+        let state = to_enc_error!(
+            generichash::State::new(Some(32), key),
+            "Failed to init hash"
+        )?;
 
         Ok(Self { state })
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -261,7 +261,7 @@ impl LoginCryptoManager {
         pubkey: &[u8; sign::PUBLICKEYBYTES],
     ) -> Result<bool> {
         let mut signature_copy = [0; 64];
-        signature_copy[..].copy_from_slice(&signature[..]);
+        signature_copy[..].copy_from_slice(signature);
         let signature = to_enc_error!(
             sign::Signature::from_bytes(&signature_copy),
             "siganture copy failed"

--- a/src/online_managers.rs
+++ b/src/online_managers.rs
@@ -509,7 +509,7 @@ impl CollectionManagerOnline {
             collection_types: Vec<&'b Bytes>,
         }
 
-        let collection_types: Vec<&Bytes> = collection_types.map(|x| Bytes::new(x)).collect();
+        let collection_types: Vec<&Bytes> = collection_types.map(Bytes::new).collect();
 
         let body_struct = Body { collection_types };
         let body = rmp_serde::to_vec_named(&body_struct)?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -316,7 +316,7 @@ impl Account {
                 .client
                 .server_url()
                 .host_str()
-                .unwrap_or(self.client.server_url().as_str()),
+                .unwrap_or_else(|| self.client.server_url().as_str()),
             action: "login",
         };
         let response = rmp_serde::to_vec_named(&response_struct)?;
@@ -388,7 +388,7 @@ impl Account {
                 .client
                 .server_url()
                 .host_str()
-                .unwrap_or(self.client.server_url().as_str()),
+                .unwrap_or_else(|| self.client.server_url().as_str()),
             action: "changePassword",
 
             login_pubkey: login_crypto_manager.pubkey(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,7 +84,7 @@ pub fn to_base64(bytes: &[u8]) -> Result<StringBase64> {
 // Fisher–Yates shuffle - an unbiased shuffler
 // The returend indices of where item is now.
 // So if the first item moved to position 3: ret[0] = 3
-pub(crate) fn shuffle<T>(a: &mut Vec<T>) -> Vec<usize> {
+pub(crate) fn shuffle<T>(a: &mut [T]) -> Vec<usize> {
     let len = a.len();
     let mut shuffled_indices: Vec<usize> = (0..len).collect();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,7 +25,7 @@ pub struct TestUser {
 }
 
 #[allow(non_upper_case_globals)]
-pub const sessionStorageKey: &'static str = "YA0cMVJ9Q_SKYJCvKNni9y13vf62rEIq8M6kjtT14b4";
+pub const sessionStorageKey: &str = "YA0cMVJ9Q_SKYJCvKNni9y13vf62rEIq8M6kjtT14b4";
 
 pub const USER: TestUser = TestUser {
   username: "test_user",

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -80,7 +80,7 @@ fn login_crypto_manager() {
     let signature = login_crypto_manager.sign_detached(msg).unwrap();
     let pubkey = login_crypto_manager.pubkey();
     assert!(login_crypto_manager
-        .verify_detached(msg, &signature, (&pubkey[..]).try_into().unwrap())
+        .verify_detached(msg, &signature, pubkey.try_into().unwrap())
         .unwrap());
 }
 
@@ -93,13 +93,10 @@ fn box_crypto_manager() {
 
     let msg = b"This Is Some Test Cleartext.";
     let cipher = box_crypto_manager
-        .encrypt(msg, (&box_crypto_manager2.pubkey()[..]).try_into().unwrap())
+        .encrypt(msg, box_crypto_manager2.pubkey().try_into().unwrap())
         .unwrap();
     let decrypted = box_crypto_manager2
-        .decrypt(
-            &cipher[..],
-            (&box_crypto_manager.pubkey()[..]).try_into().unwrap(),
-        )
+        .decrypt(&cipher[..], box_crypto_manager.pubkey().try_into().unwrap())
         .unwrap();
     assert_eq!(decrypted, msg);
 }

--- a/tests/fs_cache.rs
+++ b/tests/fs_cache.rs
@@ -32,8 +32,8 @@ impl TempDir {
 
         let path = tmpdir.join(&name);
         match std::fs::create_dir(&path) {
-            Ok(_) => return Ok(TempDir { path }),
-            Err(e) => return Err(e),
+            Ok(_) => Ok(TempDir { path }),
+            Err(e) => Err(e),
         }
     }
 


### PR DESCRIPTION
This PR reworks the GitHub Actions configuration to:
1. Enforce code formatting using `cargo fmt` (fixes #16)
2. Make clippy more strict by denying warnings in CI
3. Make test/clippy/fmt run in parallel, so they all produce results quicker and don't shadow each other on failure

To then make the CI green again, I ran `cargo fmt` and `cargo clippy --fix`, and solved a couple more clippy lints by hand.