### PR TITLE
Add MSRV

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,18 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+  stable-tests:
+    name: Run tests on stable rust
+    uses: ./.github/workflows/test.yml
+    with:
+      rust-version: stable
+
+  msrv-tests:
+    name: Run tests on the minimum supported rust version
+    uses: ./.github/workflows/test.yml
+    with:
+      rust-version: 1.56.0 # also change in Cargo.toml and README.md
+
   formatting:
     name: Code formatting
     runs-on: ubuntu-latest
@@ -35,25 +47,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features -- -D warnings
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Run local test Server
-        run: |
-          docker run -d -p 3735:3735 etesync/test-server:latest
-          ./scripts/wait-for-it.sh localhost:3735
-
-      - name: Run tests
-        env:
-          ETEBASE_TEST_HOST: localhost:3735
-        run: cargo test -- --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      rust-version:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run local test Server
+        run: |
+          docker run -d -p 3735:3735 etesync/test-server:latest
+          ./scripts/wait-for-it.sh localhost:3735
+
+      - name: Run tests
+        env:
+          ETEBASE_TEST_HOST: localhost:3735
+        run: cargo test -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/etesync/etebase-rs/"
 version = "0.5.3"
 authors = ["Tom Hacohen <tom@stosb.com>"]
 edition = "2018"
+rust-version = "1.56.0"
 license = "BSD-3-Clause"
 readme = "README.md"
 keywords = ["encryption", "sync", "etesync", "cryptography", "firebase"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ In addition to exposing a Rust API, this library forms the basis of other Etebas
 
 In addition to the API documentation, there are docs available at https://docs.etebase.com
 
+# Minimum supported Rust version (MSRV)
+
+The current MSRV is 1.56.0. Changes to the MSRV are not considered breaking and may occur in any patch release, it is however guaranteed that
+at least the previous Rust version will always be supported. This results in a three-month grace period from when a new Rust verion is released
+until it may become required.
+
 # Build
 
 To build:


### PR DESCRIPTION
This PR specifies the current MSRV (some dependencies use `edition="2021"`, which became stable in 1.56), adds a CI check to make sure it is actually upheld, and outlines a policy for future MSRV changes.

I made the policy up more or less on the spot - from my experience talking to other Rust developers, supporting old Rust versions isn't actually that big of a big concern since most devs update their toolchain fairly quickly, so a 3-month period should be plenty. @tasn thoughts?

Fixes #28