### PR TITLE
SignedInvitation: rename from_* methods

### DIFF
--- a/src/encrypted_models.rs
+++ b/src/encrypted_models.rs
@@ -239,16 +239,26 @@ impl SignedInvitation {
     }
 
     /// The username this invitation is form
-    pub fn from_username(&self) -> Option<&str> {
+    pub fn sender_username(&self) -> Option<&str> {
         self.from_username.as_deref()
     }
 
     /// The public key of the inviting user
-    pub fn from_pubkey(&self) -> &[u8] {
+    pub fn sender_pubkey(&self) -> &[u8] {
         match self.from_pubkey.as_deref() {
             Some(from_pubkey) => from_pubkey,
             None => panic!("Can never happen. Tried getting empty pubkey."),
         }
+    }
+
+    #[deprecated = "This method has been renamed to sender_username() to avoid potential confusion regarding its name"]
+    pub fn from_username(&self) -> Option<&str> {
+        self.sender_username()
+    }
+
+    #[deprecated = "This method has been renamed to sender_pubkey() to avoid potential confusion regarding its name"]
+    pub fn from_pubkey(&self) -> &[u8] {
+        self.sender_pubkey()
     }
 
     pub(crate) fn decrypted_encryption_key(

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -1036,7 +1036,7 @@ fn collection_invitations() -> Result<()> {
     assert_eq!(invitations.data().len(), 1);
     {
         let invitation = invitations.data().first().unwrap();
-        assert_eq!(invitation.from_username().unwrap(), USER.username);
+        assert_eq!(invitation.sender_username().unwrap(), USER.username);
     }
 
     invite_mgr2.reject(invitations.data().first().unwrap())?;
@@ -1084,7 +1084,7 @@ fn collection_invitations() -> Result<()> {
     // Should be verified by user2 off-band
     let user1_pubkey = invite_mgr.pubkey();
     let invitation = invitations.data().first().unwrap();
-    assert_eq!(invitation.from_pubkey(), user1_pubkey);
+    assert_eq!(invitation.sender_pubkey(), user1_pubkey);
 
     invite_mgr2.accept(invitation)?;
 


### PR DESCRIPTION
Methods starting with `from_` are usually reserved as constructors using a value of some other type as input, whereas here they are getters for the data of the invitation's sender (the account the invitation came *from*).