### PR TITLE
Reduce test_helpers module further

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub mod managers {
     };
 }
 
+/// Helper functions for integration tests. Any items in this module is not considered part of the
+/// public API and may change at any time.
 #[doc(hidden)]
 pub mod test_helpers {
     pub use super::{online_managers::test_reset, service::test_chunk_uids as chunk_uids};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,7 @@ pub mod managers {
 
 #[doc(hidden)]
 pub mod test_helpers {
-    pub use super::online_managers::{
-        // Test stuff
-        test_reset,
-        SignupBody,
-    };
+    pub use super::online_managers::test_reset;
 
     pub fn chunk_uids(item: &crate::Item) -> Vec<String> {
         super::service::test_chunk_uids(item)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,7 @@ pub mod managers {
 
 #[doc(hidden)]
 pub mod test_helpers {
-    pub use super::online_managers::test_reset;
-
-    pub fn chunk_uids(item: &crate::Item) -> Vec<String> {
-        super::service::test_chunk_uids(item)
-    }
+    pub use super::{online_managers::test_reset, service::test_chunk_uids as chunk_uids};
 }
 
 pub const CURRENT_VERSION: u8 = 1;

--- a/src/online_managers.rs
+++ b/src/online_managers.rs
@@ -17,7 +17,22 @@ use super::error::{Error, Result};
 use super::http_client::Client;
 use crate::utils::{StrBase64, StringBase64};
 
-pub fn test_reset(client: &Client, body_struct: SignupBody) -> Result<()> {
+/// Resets/reinitializes a given user account. Only used for integration tests, not part of public API.
+pub fn test_reset(
+    client: &Client,
+    user: &User,
+    salt: &[u8],
+    login_pubkey: &[u8],
+    pubkey: &[u8],
+    encrypted_content: &[u8],
+) -> Result<()> {
+    let body_struct = SignupBody {
+        user,
+        salt,
+        login_pubkey,
+        pubkey,
+        encrypted_content,
+    };
     let body = rmp_serde::to_vec_named(&body_struct)?;
     let url = client.api_base.join("api/v1/test/authentication/reset/")?;
 
@@ -138,7 +153,7 @@ pub(crate) struct LoginChallange {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SignupBody<'a> {
+pub(crate) struct SignupBody<'a> {
     pub user: &'a User,
     #[serde(with = "serde_bytes")]
     pub salt: &'a [u8],

--- a/src/service.rs
+++ b/src/service.rs
@@ -1494,6 +1494,7 @@ impl Item {
     }
 }
 
-pub(crate) fn test_chunk_uids(item: &Item) -> Vec<String> {
+/// Returns the UIDs of an item's chunks. Only used for integration tests, not part of public API.
+pub fn test_chunk_uids(item: &Item) -> Vec<String> {
     item.item.test_chunk_uids()
 }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -35,14 +35,14 @@ fn user_reset(user: &TestUser) -> Result<()> {
         &acct_user,
         b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     );
-    let body_struct = etebase::test_helpers::SignupBody {
-        user: &acct_user,
-        salt: &from_base64(user.salt)?,
-        pubkey: &from_base64(user.pubkey)?,
-        login_pubkey: &from_base64(user.loginPubkey)?,
-        encrypted_content: &from_base64(user.encryptedContent)?,
-    };
-    etebase::test_helpers::test_reset(&client, body_struct)?;
+    etebase::test_helpers::test_reset(
+        &client,
+        &acct_user,
+        &from_base64(user.salt)?,
+        &from_base64(user.loginPubkey)?,
+        &from_base64(user.pubkey)?,
+        &from_base64(user.encryptedContent)?,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Followup to #37, now only the `test_reset` and `chunk_uids` functions are left exposed - both of these are used exclusively for tests, so all actual internals should be removed from the (theoretically) public API now.