### PR TITLE
fix(openssl): bump to address CVE-2025-3416

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde = { version = "^1.0.136", features = ["derive"] }
 serde_bytes = "^0.11.5"
 serde_repr = "^0.1.7"
 rmp-serde = "^1.1.0"
-openssl-sys = "^0.9.84"
-openssl = "^0.10.48"
+openssl-sys = "^0.9.108"
+openssl = "^0.10.72"
 reqwest = { version = "^0.11.10", features = ["blocking"], optional = true }
 remove_dir_all = "^0.8.2"
 


### PR DESCRIPTION
See also https://bugzilla.suse.com/show_bug.cgi?id=1242638

Closes https://github.com/etesync/etebase-rs/issues/46